### PR TITLE
Add secure tool-specific API key management <speculative, deep assessment needed.>

### DIFF
--- a/server/src/mcp/sessionManager.ts
+++ b/server/src/mcp/sessionManager.ts
@@ -1,15 +1,24 @@
 // server/src/mcp/sessionManager.ts
 import { v4 as uuidv4 } from "uuid";
+import crypto from "crypto";
+
+interface ToolCredential {
+  toolName: string;
+  serverId: string;
+  data: string; // Encrypted credentials
+}
 
 interface Session {
   id: string;
   anthropicApiKey?: string;
+  credentials: ToolCredential[];
   createdAt: Date;
   lastActive: Date;
 }
 
 export class SessionManager {
   private sessions: Map<string, Session> = new Map();
+  private encryptionKey: Buffer;
 
   // Session cleanup interval in milliseconds (1 hour)
   private readonly CLEANUP_INTERVAL = 60 * 60 * 1000;
@@ -17,6 +26,13 @@ export class SessionManager {
   constructor() {
     // Set up session cleanup
     setInterval(() => this.cleanupSessions(), this.CLEANUP_INTERVAL);
+    
+    // Generate or load encryption key (in production, this should be loaded from a secure source)
+    this.encryptionKey = Buffer.from(
+      process.env.CREDENTIAL_ENCRYPTION_KEY || 
+      crypto.randomBytes(32).toString('hex'), 
+      'hex'
+    );
   }
 
   createSession(): string {
@@ -25,6 +41,7 @@ export class SessionManager {
 
     this.sessions.set(sessionId, {
       id: sessionId,
+      credentials: [],
       createdAt: now,
       lastActive: now,
     });
@@ -56,6 +73,94 @@ export class SessionManager {
 
   getAnthropicApiKey(sessionId: string): string | undefined {
     return this.sessions.get(sessionId)?.anthropicApiKey;
+  }
+
+  // Store credentials for a tool
+  setToolCredentials(
+    sessionId: string, 
+    toolName: string, 
+    serverId: string, 
+    credentials: Record<string, string>
+  ): void {
+    const session = this.sessions.get(sessionId);
+    if (!session) return;
+
+    // Remove any existing credentials for this tool
+    session.credentials = session.credentials.filter(
+      cred => !(cred.toolName === toolName && cred.serverId === serverId)
+    );
+
+    // Encrypt the credentials
+    const encrypted = this.encryptData(JSON.stringify(credentials));
+    
+    // Add the new credentials
+    session.credentials.push({
+      toolName,
+      serverId,
+      data: encrypted
+    });
+
+    session.lastActive = new Date();
+    this.sessions.set(sessionId, session);
+  }
+
+  // Get credentials for a tool
+  getToolCredentials(
+    sessionId: string,
+    toolName: string,
+    serverId: string
+  ): Record<string, string> | null {
+    const session = this.sessions.get(sessionId);
+    if (!session) return null;
+
+    const credential = session.credentials.find(
+      cred => cred.toolName === toolName && cred.serverId === serverId
+    );
+
+    if (!credential) return null;
+
+    try {
+      // Decrypt the credentials
+      const decrypted = this.decryptData(credential.data);
+      return JSON.parse(decrypted);
+    } catch (error) {
+      console.error(`Error decrypting credentials for tool ${toolName}:`, error);
+      return null;
+    }
+  }
+
+  // Encrypt data using AES-256-GCM
+  private encryptData(data: string): string {
+    const iv = crypto.randomBytes(16);
+    const cipher = crypto.createCipheriv('aes-256-gcm', this.encryptionKey, iv);
+    
+    const encrypted = Buffer.concat([
+      cipher.update(data, 'utf8'),
+      cipher.final()
+    ]);
+    
+    const authTag = cipher.getAuthTag();
+    
+    // Return IV + AuthTag + Encrypted data as base64 string
+    return Buffer.concat([iv, authTag, encrypted]).toString('base64');
+  }
+
+  // Decrypt data using AES-256-GCM
+  private decryptData(encryptedBase64: string): string {
+    const encryptedBuffer = Buffer.from(encryptedBase64, 'base64');
+    
+    // Extract IV, AuthTag, and encrypted data
+    const iv = encryptedBuffer.subarray(0, 16);
+    const authTag = encryptedBuffer.subarray(16, 32);
+    const encrypted = encryptedBuffer.subarray(32);
+    
+    const decipher = crypto.createDecipheriv('aes-256-gcm', this.encryptionKey, iv);
+    decipher.setAuthTag(authTag);
+    
+    return Buffer.concat([
+      decipher.update(encrypted),
+      decipher.final()
+    ]).toString('utf8');
   }
 
   private cleanupSessions(): void {

--- a/server/src/mcp/toolRegistry.ts
+++ b/server/src/mcp/toolRegistry.ts
@@ -1,22 +1,43 @@
 // server/src/mcp/toolRegistry.ts
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { CredentialRequirement, ToolInfo as SharedToolInfo } from "../../shared/types.js";
 
 interface ToolInfo {
   serverId: string;
+  serverName: string;
   client: Client;
   tool: Tool;
+  credentialRequirements?: CredentialRequirement[];
 }
 
 export class ToolRegistry {
   private tools: Map<string, ToolInfo> = new Map();
 
-  registerTools(serverId: string, client: Client, tools: Tool[]): void {
+  registerTools(serverId: string, serverName: string, client: Client, tools: Tool[]): void {
     for (const tool of tools) {
+      // Extract credential requirements if present in the tool definition
+      const credentialRequirements = (tool.inputSchema as any)?.__credentials?.required?.map(
+        (id: string): CredentialRequirement => {
+          const acquisition = (tool.inputSchema as any)?.__credentials?.acquisition;
+          return {
+            id,
+            name: id.replace(/[-_]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase()),
+            description: (tool.inputSchema as any)?.__credentials?.descriptions?.[id],
+            acquisition: acquisition ? {
+              url: acquisition.url,
+              instructions: acquisition.instructions
+            } : undefined
+          };
+        }
+      );
+
       this.tools.set(tool.name, {
         serverId,
+        serverName,
         client,
         tool,
+        credentialRequirements
       });
     }
   }
@@ -25,14 +46,40 @@ export class ToolRegistry {
     return this.tools.get(toolName);
   }
 
-  getAllTools(): Tool[] {
-    return Array.from(this.tools.values()).map((info) => info.tool);
+  getAllTools(): SharedToolInfo[] {
+    return Array.from(this.tools.values()).map((info) => ({
+      name: info.tool.name,
+      description: info.tool.description,
+      inputSchema: info.tool.inputSchema,
+      credentialRequirements: info.credentialRequirements
+    }));
   }
 
-  getToolsByServerId(serverId: string): Tool[] {
+  getToolsByServerId(serverId: string): SharedToolInfo[] {
     return Array.from(this.tools.values())
       .filter((info) => info.serverId === serverId)
-      .map((info) => info.tool);
+      .map((info) => ({
+        name: info.tool.name,
+        description: info.tool.description,
+        inputSchema: info.tool.inputSchema,
+        credentialRequirements: info.credentialRequirements
+      }));
+  }
+
+  getToolsWithCredentialRequirements(): { 
+    toolName: string; 
+    serverName: string;
+    serverId: string;
+    credentials: CredentialRequirement[];
+  }[] {
+    return Array.from(this.tools.values())
+      .filter(info => info.credentialRequirements && info.credentialRequirements.length > 0)
+      .map(info => ({
+        toolName: info.tool.name,
+        serverName: info.serverName,
+        serverId: info.serverId,
+        credentials: info.credentialRequirements || []
+      }));
   }
 
   removeToolsByServerId(serverId: string): void {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -60,12 +60,44 @@ export interface ApiKeyResponse {
   success: boolean;
 }
 
+// New interfaces for tool credential management
+export interface CredentialRequirement {
+  id: string;
+  name: string;
+  description?: string;
+  acquisition?: {
+    url?: string;
+    instructions?: string;
+  };
+}
+
+export interface ToolCredentialInfo {
+  toolName: string;
+  serverName: string;
+  serverId: string;
+  credentials: CredentialRequirement[];
+}
+
+export interface ToolCredentialRequest {
+  toolName: string;
+  serverId: string;
+  credentials: Record<string, string>;
+}
+
+export interface ToolCredentialResponse {
+  success: boolean;
+  error?: string;
+}
+
+export interface ToolInfo {
+  name: string;
+  description?: string;
+  inputSchema: any;
+  credentialRequirements?: CredentialRequirement[];
+}
+
 export interface ToolsListResponse {
-  tools: Array<{
-    name: string;
-    description?: string;
-    inputSchema: any;
-  }>;
+  tools: ToolInfo[];
 }
 
 export interface ServersListResponse {


### PR DESCRIPTION
This Speculative PR adds support for tool-specific API key management with the following features:

   - Tools can declare credential requirements through a standard interface
   - Users can configure credentials for tools through the settings UI
   - Credentials are securely encrypted with AES-256-GCM in the session store
   - Tool credentials are automatically passed when executing tool calls

   Security considerations:
   - Credentials are encrypted at rest
   - Credentials are bound to specific user sessions
   - HTTPS is required for secure transmission
   - No plaintext storage of sensitive information

   This implementation is minimally invasive but also speculative. It is intended to help fast-track API key management for tools, but it likely will not be the final implementation. To test and debug this locally, consider something like:
   
      git fetch origin
   git checkout feature/tool-credentials